### PR TITLE
feat: add LocalLaunchConfig support for customizable pub get and dart run args

### DIFF
--- a/fixture_packages/example_v1/bin/example.dart
+++ b/fixture_packages/example_v1/bin/example.dart
@@ -11,7 +11,20 @@ void main(List<String> args) {
           'local version ${context.localInstallation?.version} and '
           'global version ${context.globalInstallation?.version}.',
         );
+
+        assert(() {
+          print('Assertions are enabled.');
+          return true;
+        }());
       },
+      resolveLocalLaunchConfig: args.contains('--local-launch-config')
+          ? (context) async {
+              return LocalLaunchConfig(
+                pubGetArgs: ['--verbose'],
+                dartRunArgs: ['--enable-asserts'],
+              );
+            }
+          : null,
     ),
   );
 }

--- a/test/e2e_test.dart
+++ b/test/e2e_test.dart
@@ -95,13 +95,46 @@ void main() {
         ),
       );
     });
+
+    test('with local launch config', () {
+      final output = runExampleCli(
+        workingDirectory: './fixture_packages/consumer_v1',
+        arguments: ['--local-launch-config'],
+        forcePubGet: true,
+      );
+
+      // Verify that `dart pub get` was run with `--verbose`.
+      expect(
+        output,
+        matches(
+          'MSG : Resolving dependencies...',
+        ),
+      );
+
+      // Verify that `dart run` was run with `--enable-asserts`.
+      expect(
+        output,
+        matches(
+          'Assertions are enabled.',
+        ),
+      );
+    });
   });
 }
 
 String runExampleCli({
   List<String> arguments = const [],
   required String workingDirectory,
+  bool forcePubGet = false,
 }) {
+  if (forcePubGet) {
+    // Remove the pubspec.lock file to ensure a fresh run.
+    final lockFile = File('$workingDirectory/pubspec.lock');
+    if (lockFile.existsSync()) {
+      lockFile.deleteSync();
+    }
+  }
+
   final result = Process.runSync(
     'example',
     arguments,

--- a/test/e2e_test.dart
+++ b/test/e2e_test.dart
@@ -104,20 +104,10 @@ void main() {
       );
 
       // Verify that `dart pub get` was run with `--verbose`.
-      expect(
-        output,
-        matches(
-          'MSG : Resolving dependencies...',
-        ),
-      );
+      expect(output, matches('MSG : Resolving dependencies...'));
 
       // Verify that `dart run` was run with `--enable-asserts`.
-      expect(
-        output,
-        matches(
-          'Assertions are enabled.',
-        ),
-      );
+      expect(output, matches('Assertions are enabled.'));
     });
   });
 }


### PR DESCRIPTION
## Summary
• Add LocalLaunchConfig class for configuring local launch behavior
• Add ResolveLocalLaunchConfig typedef for dynamic configuration resolution
• Support custom arguments for both `dart pub get` and `dart run` commands
• Add comprehensive test coverage for the new functionality

## Test Plan
- [x] Unit tests verify custom pub get args are passed correctly
- [x] Unit tests verify custom dart run args are applied
- [x] E2E test confirms --verbose flag appears in pub get output
- [x] E2E test confirms --enable-asserts flag enables assertions

🤖 Generated with [Claude Code](https://claude.ai/code)