### PR TITLE
fix: Use exact path matching for package name detection in global installations

### DIFF
--- a/lib/cli_launcher.dart
+++ b/lib/cli_launcher.dart
@@ -319,7 +319,9 @@ ExecutableInstallation _findGlobalInstallation(ExecutableName executable) {
   Directory? lockFileRootOverride;
 
   final scriptPath = Platform.script.toFilePath();
-  if (scriptPath.contains(path.join('global_packages', executable.package))) {
+  if (scriptPath.contains(
+    path.join('global_packages', executable.package) + path.separator,
+  )) {
     // The snapshot of an executable that is globally installed in the pub cache
     // is located in the `bin` directory in a generated package.
     // This package is located in `<pub-cache>/global_packages/<package>`.
@@ -328,7 +330,7 @@ ExecutableInstallation _findGlobalInstallation(ExecutableName executable) {
       'Detected pub cache global installation at ${_relativePath(packageRoot.path)}.',
     );
   } else if (scriptPath.contains(
-    path.join('.dart_tool', 'pub', 'bin', executable.package),
+    path.join('.dart_tool', 'pub', 'bin', executable.package) + path.separator,
   )) {
     final (:root, :lockFileRoot) = _findPathActivatedPackageRoot(
       scriptPath,
@@ -465,9 +467,7 @@ ExecutableInstallation? _findLocalInstallation(
       if (workspace != null && !isSelf) {
         for (final entry in workspace) {
           final memberPath = path.join(start.path, entry as String);
-          final memberPubspecFile = File(
-            path.join(memberPath, 'pubspec.yaml'),
-          );
+          final memberPubspecFile = File(path.join(memberPath, 'pubspec.yaml'));
           if (memberPubspecFile.existsSync()) {
             final memberPubspecString = memberPubspecFile.readAsStringSync();
             final memberPubspecYaml = loadYamlDocument(
@@ -487,7 +487,8 @@ ExecutableInstallation? _findLocalInstallation(
           }
         }
       } else if (resolution == 'workspace') {
-        lockFileRoot = _findWorkspaceRoot(start) ??
+        lockFileRoot =
+            _findWorkspaceRoot(start) ??
             (throw StateError(
               'Could not find workspace root for package at '
               '${start.path}. The pubspec.yaml has '

--- a/lib/cli_launcher.dart
+++ b/lib/cli_launcher.dart
@@ -433,6 +433,7 @@ ExecutableInstallation? _findLocalInstallation(
     String? resolution;
     YamlMap? dependencies;
     YamlMap? devDependencies;
+    YamlList? workspace;
 
     try {
       final pubspecYaml = loadYamlDocument(
@@ -444,6 +445,7 @@ ExecutableInstallation? _findLocalInstallation(
       resolution = pubspec['resolution'] as String?;
       dependencies = pubspec['dependencies'] as YamlMap?;
       devDependencies = pubspec['dev_dependencies'] as YamlMap?;
+      workspace = pubspec['workspace'] as YamlList?;
     } catch (error) {
       throw StateError('Could not parse ${pubspecFile.path}: $error');
     }
@@ -455,23 +457,54 @@ ExecutableInstallation? _findLocalInstallation(
             dependencies.containsKey(executable.package)) ||
         (devDependencies != null &&
             devDependencies.containsKey(executable.package))) {
+      // If this is a workspace root and the executable package is a workspace
+      // member, resolve the actual package directory instead of using the
+      // workspace root as the package root.
+      var packageRoot = start;
+      Directory? lockFileRoot;
+      if (workspace != null && !isSelf) {
+        for (final entry in workspace) {
+          final memberPath = path.join(start.path, entry as String);
+          final memberPubspecFile = File(
+            path.join(memberPath, 'pubspec.yaml'),
+          );
+          if (memberPubspecFile.existsSync()) {
+            final memberPubspecString = memberPubspecFile.readAsStringSync();
+            final memberPubspecYaml = loadYamlDocument(
+              memberPubspecString,
+              sourceUrl: memberPubspecFile.uri,
+            );
+            final memberPubspec = memberPubspecYaml.contents as YamlMap;
+            if (memberPubspec['name'] == executable.package) {
+              packageRoot = Directory(memberPath);
+              lockFileRoot = start;
+              _debug(
+                'Resolved workspace member at '
+                '${_relativePath(memberPath)}.',
+              );
+              break;
+            }
+          }
+        }
+      } else if (resolution == 'workspace') {
+        lockFileRoot = _findWorkspaceRoot(start) ??
+            (throw StateError(
+              'Could not find workspace root for package at '
+              '${start.path}. The pubspec.yaml has '
+              '"resolution: workspace" but no parent directory '
+              'contains a pubspec.yaml with a "workspace" field.',
+            ));
+      }
+
       _debug(
-        'Found local installation at ${_relativePath(start.path)} '
+        'Found local installation at ${_relativePath(packageRoot.path)} '
         '(isSelf: $isSelf, resolution: $resolution).',
       );
       return ExecutableInstallation(
         name: executable,
         isSelf: isSelf,
-        packageRoot: start,
-        lockFileRoot: resolution == 'workspace'
-            ? _findWorkspaceRoot(start) ??
-                  (throw StateError(
-                    'Could not find workspace root for package at '
-                    '${start.path}. The pubspec.yaml has '
-                    '"resolution: workspace" but no parent directory '
-                    'contains a pubspec.yaml with a "workspace" field.',
-                  ))
-            : null,
+        packageRoot: packageRoot,
+        lockFileRoot: lockFileRoot,
       );
     }
   }

--- a/test/e2e_matrix_test.dart
+++ b/test/e2e_matrix_test.dart
@@ -112,6 +112,29 @@ void main() {
           expect(stderr, contains('Launching local installation'));
         });
 
+        // --- Running from workspace root ---
+
+        test(
+          'launches from workspace root with cli as dev_dependency',
+          () {
+            if (fixture!.workspaceRootDir == null) {
+              return;
+            }
+            fixture!.ensureUpToDateTimestamps();
+
+            final (:stdout, :stderr) = fixture!.runCli(
+              workingDirectory: fixture!.workspaceRootDir!,
+            );
+            expect(stdout, contains('local=1.0.0'));
+            expect(stdout, contains('global=1.0.0'));
+            expect(stderr, contains('Resolved workspace member'));
+            expect(stderr, contains('Launching local installation'));
+          },
+          skip: structure == PackageStructure.standalone
+              ? 'standalone has no workspace root'
+              : null,
+        );
+
         // --- Consumer from sub-directory ---
 
         test('launches from sub-directory of consumer', () {
@@ -450,7 +473,9 @@ class _Fixture {
       'packages',
       'dev_dep_consumer',
     );
-    final emptyDir = p.join(workspaceDir, 'empty');
+    // Empty dir must be outside the workspace so that the "no local
+    // installation" test doesn't find the workspace root's dev_dependency.
+    final emptyDir = p.join(tempDir.path, 'empty');
 
     // v2 packages live outside the workspace to avoid name conflicts.
     final v2CliDir = p.join(tempDir.path, 'cli_package_v2');
@@ -464,12 +489,18 @@ class _Fixture {
       if (flutter) 'packages/flutter_package',
     ];
 
+    // The workspace root lists the CLI package as a dev_dependency (like the
+    // melos repo does for itself) to test that running from the workspace root
+    // correctly resolves the workspace member as the package root.
     File(p.join(workspaceDir, 'pubspec.yaml')).writeAsStringSync('''
 name: matrix_workspace
 environment:
   sdk: ^3.8.0
 workspace:
 ${workspaceMembers.map((m) => '  - $m').join('\n')}
+dev_dependencies:
+  $packageName:
+    path: packages/cli_package
 ''');
 
     _createCliPackage(

--- a/test/e2e_matrix_test.dart
+++ b/test/e2e_matrix_test.dart
@@ -275,6 +275,200 @@ void main() {
       });
     }
   }
+
+  // Tests activating a workspace member CLI package directly from the
+  // workspace root, where the workspace root has the CLI as a dev_dependency.
+  group('workspace member activated from workspace root', () {
+    _WorkspaceRootActivationFixture? fixture;
+
+    setUpAll(() async {
+      fixture = await _WorkspaceRootActivationFixture.create();
+    });
+
+    tearDownAll(() {
+      fixture?.dispose();
+    });
+
+    test('launches correctly from empty directory', () {
+      final (:stdout, :stderr) = fixture!.runCli(
+        workingDirectory: fixture!.emptyDir,
+      );
+      expect(stdout, contains('local=null'));
+      expect(stdout, contains('global=1.0.0'));
+      expect(stderr, contains('No local installation found'));
+    });
+
+    test('launches correctly from workspace root', () {
+      fixture!.ensureUpToDateTimestamps();
+
+      final (:stdout, :stderr) = fixture!.runCli(
+        workingDirectory: fixture!.workspaceRootDir,
+      );
+      expect(stdout, contains('local=1.0.0'));
+      expect(stdout, contains('global=1.0.0'));
+      expect(stderr, contains('Resolved workspace member'));
+      expect(stderr, contains('Launching local installation'));
+    });
+  });
+}
+
+/// Fixture that activates a workspace member CLI package directly from the
+/// workspace root, where the root has the CLI as a dev_dependency.
+///
+/// This reproduces the pattern used in the melos repo:
+///
+/// - Workspace root: `melos_workspace` with `melos` as dev_dependency
+/// - CLI member: `melos` at `packages/melos`
+/// - Activated via `dart pub global activate --source=path packages/melos`
+class _WorkspaceRootActivationFixture {
+  _WorkspaceRootActivationFixture._({
+    required this.tempDir,
+    required this.workspaceRootDir,
+    required this.cliPackageDir,
+    required this.emptyDir,
+    required this.executableName,
+    required this.packageName,
+  });
+
+  final String tempDir;
+  final String workspaceRootDir;
+  final String cliPackageDir;
+  final String emptyDir;
+  final String executableName;
+  final String packageName;
+
+  void ensureUpToDateTimestamps() {
+    _ensureUpToDateTimestamps(workspaceRootDir);
+    _ensureUpToDateTimestamps(cliPackageDir);
+  }
+
+  static Future<_WorkspaceRootActivationFixture> create() async {
+    const packageName = 'ws_member_cli';
+    const executableName = 'ws_member_cli_exec';
+
+    final tempDir = Directory.systemTemp.createTempSync(
+      'cli_launcher_ws_member_',
+    );
+
+    try {
+      final workspaceDir = p.join(tempDir.path, 'workspace');
+      final cliDir = p.join(workspaceDir, 'packages', 'cli_package');
+      final emptyDir = p.join(tempDir.path, 'empty');
+
+      // Create workspace root with the CLI package as a dev_dependency.
+      Directory(workspaceDir).createSync(recursive: true);
+      File(p.join(workspaceDir, 'pubspec.yaml')).writeAsStringSync('''
+name: ws_member_workspace
+environment:
+  sdk: ^3.8.0
+workspace:
+  - packages/cli_package
+dev_dependencies:
+  $packageName:
+    path: packages/cli_package
+''');
+
+      // Create the CLI member package.
+      Directory(p.join(cliDir, 'bin')).createSync(recursive: true);
+      Directory(p.join(cliDir, 'lib')).createSync(recursive: true);
+
+      File(p.join(cliDir, 'pubspec.yaml')).writeAsStringSync('''
+name: $packageName
+version: 1.0.0
+resolution: workspace
+environment:
+  sdk: ^3.8.0
+dependencies:
+  cli_launcher:
+    path: $_cliLauncherRoot
+executables:
+  $executableName:
+''');
+
+      // Create the CLI entrypoint in the member package.
+      File(p.join(cliDir, 'bin', '$executableName.dart')).writeAsStringSync('''
+import 'package:cli_launcher/cli_launcher.dart';
+
+void main(List<String> args) {
+  launchExecutable(
+    args,
+    LaunchConfig(
+      name: ExecutableName('$executableName', package: '$packageName'),
+      entrypoint: (args, context) {
+        print(
+          'local=\${context.localInstallation?.version} '
+          'global=\${context.globalInstallation?.version}',
+        );
+      },
+    ),
+  );
+}
+''');
+
+      Directory(emptyDir).createSync();
+
+      // Resolve workspace dependencies.
+      _Fixture._runSync('dart', ['pub', 'get'], workingDirectory: workspaceDir);
+
+      // Activate the CLI member package directly from the workspace root.
+      // This mirrors how melos does:
+      //   dart pub global activate --source="path" packages/melos --executable="melos"
+      _Fixture._runSync('dart', [
+        'pub',
+        'global',
+        'activate',
+        '--source',
+        'path',
+        'packages/cli_package',
+        '--executable=$executableName',
+      ], workingDirectory: workspaceDir);
+
+      return _WorkspaceRootActivationFixture._(
+        tempDir: tempDir.path,
+        workspaceRootDir: workspaceDir,
+        cliPackageDir: cliDir,
+        emptyDir: emptyDir,
+        executableName: executableName,
+        packageName: packageName,
+      );
+    } catch (e) {
+      tempDir.deleteSync(recursive: true);
+      rethrow;
+    }
+  }
+
+  ({String stdout, String stderr}) runCli({required String workingDirectory}) {
+    final env = {...Platform.environment, 'CLI_LAUNCHER_VERBOSE': '1'};
+
+    final result = Process.runSync(
+      executableName,
+      [],
+      runInShell: true,
+      workingDirectory: workingDirectory,
+      stdoutEncoding: utf8,
+      stderrEncoding: utf8,
+      environment: env,
+    );
+
+    if (result.exitCode != 0) {
+      throw Exception(
+        '$executableName failed with exit code ${result.exitCode}:\n'
+        'stdout: ${result.stdout}\nstderr: ${result.stderr}',
+      );
+    }
+
+    return (stdout: result.stdout as String, stderr: result.stderr as String);
+  }
+
+  void dispose() {
+    Process.runSync('dart', [
+      'pub',
+      'global',
+      'deactivate',
+      packageName,
+    ], runInShell: Platform.isWindows);
+    Directory(tempDir).deleteSync(recursive: true);
+  }
 }
 
 /// Ensures pubspec.lock and package_config.json are newer than pubspec.yaml so


### PR DESCRIPTION
## Summary

- Adds trailing `path.separator` to the `global_packages/<package>` check in `_findGlobalInstallation` to prevent prefix collisions (e.g., `melos` matching `global_packages/melos_workspace/`)
- Resolves workspace member in `_findLocalInstallation` when the workspace root depends on the CLI package as a dev_dependency. Without this, `packageRoot` points to the workspace root which has no `version` field, causing a null check crash when `_launchFromGlobalInstallation` compares local and global versions.
- Adds e2e test for activating a workspace member CLI package directly from the workspace root

## Context

This fixes two issues encountered in the [melos](https://github.com/invertase/melos) repo where the workspace root (`melos_workspace`) has the CLI package (`melos`) as both a workspace member and a dev_dependency:

1. **Global installation detection**: `global_packages/melos` substring-matched `global_packages/melos_workspace/`. Fixed by requiring a trailing path separator for exact directory matching.

2. **Local installation version crash**: When running from the workspace root, `_findLocalInstallation` found the workspace root as the local installation. Since the workspace root pubspec has no `version` field, `localInstallation.version` crashed with a null check error in `_launchFromGlobalInstallation`. Fixed by resolving the actual workspace member package when the workspace root depends on the CLI package.

The companion fix in melos changes activation to point at the CLI member package directly (`packages/melos`) rather than the workspace root, and uses `lockFileRoot` instead of `packageRoot` for config resolution.

## Test plan

- Added e2e test `workspace member activated from workspace root` that activates a workspace member CLI and verifies it launches correctly from both an empty directory and the workspace root
- All existing e2e tests pass