### PR TITLE
fix: relaunch local installation with Flutter tool in Flutter workspaces

### DIFF
--- a/lib/cli_launcher.dart
+++ b/lib/cli_launcher.dart
@@ -747,19 +747,29 @@ Future<void> _launchFromGlobalInstallation(
       (localInstallation.isSelf ||
           localInstallation.isFromPath ||
           localInstallation.version != globalInstallation.version)) {
+    // We found a local installation which is different from the global
+    // installation so we launch the local installation, passing through
+    // stdio and exit code directly.
+    //
+    // When the local installation lives in a workspace that requires the
+    // Flutter SDK we launch it through `flutter pub run` instead of `dart run`.
+    // `dart run` implicitly resolves dependencies before running, and a plain
+    // `dart pub get` fails on a Flutter workspace with "requires the Flutter
+    // SDK". Using the Flutter tool keeps the launch consistent with how
+    // dependencies are resolved in [_updateDependencies].
+    final useFlutter = localInstallation.requiresFlutter;
     _debug(
-      'Launching local installation '
+      'Launching local installation via '
+      '"${useFlutter ? 'flutter pub run' : 'dart run'}" '
       '(isSelf: ${localInstallation.isSelf}, '
       'isFromPath: ${localInstallation.isFromPath}, '
       'local version: ${localInstallation.version}, '
       'global version: ${globalInstallation.version}).',
     );
-    // We found a local installation which is different from the global
-    // installation so we launch the local installation, passing through
-    // stdio and exit code directly.
     final process = await Process.start(
-      'dart',
+      useFlutter ? 'flutter' : 'dart',
       [
+        if (useFlutter) 'pub',
         'run',
         ...?localConfig?.dartRunArgs,
         config.name.toString(),
@@ -769,7 +779,8 @@ Future<void> _launchFromGlobalInstallation(
       ],
       mode: ProcessStartMode.inheritStdio,
       workingDirectory: localInstallation.packageRoot.path,
-      // Necessary so that `dart.bat` wrapper can be found on Windows.
+      // Necessary so that `dart.bat`/`flutter.bat` wrapper can be found on
+      // Windows.
       runInShell: Platform.isWindows,
     );
     exitCode = await process.exitCode;

--- a/test/e2e_matrix_test.dart
+++ b/test/e2e_matrix_test.dart
@@ -98,6 +98,35 @@ void main() {
           expect(stderr, contains('Launching local installation'));
         });
 
+        // --- Relaunch uses the Flutter tool for Flutter workspaces ---
+        //
+        // Regression test: launching a local installation implicitly resolves
+        // dependencies (`dart run` runs an implicit `dart pub get`). In a
+        // Flutter workspace a plain `dart pub get` fails with "requires the
+        // Flutter SDK", so the relaunch must go through the Flutter tool
+        // instead. This broke consumers such as supabase-flutter whose
+        // Dart-only CI activated a newer global melos than the workspace
+        // pinned, triggering a relaunch of the pinned version.
+        test('relaunch uses the correct SDK tool', () {
+          fixture!.ensureUpToDateTimestamps();
+
+          final (:stdout, :stderr) = fixture!.runCli(
+            workingDirectory: fixture!.consumerDir,
+          );
+          expect(stderr, contains('Launching local installation'));
+          if (structure == PackageStructure.flutterWorkspaceMember) {
+            expect(
+              stderr,
+              contains('Launching local installation via "flutter pub run"'),
+            );
+          } else {
+            expect(
+              stderr,
+              contains('Launching local installation via "dart run"'),
+            );
+          }
+        });
+
         // --- Consumer with dev_dependency ---
 
         test('launches from dev_dependency consumer', () {


### PR DESCRIPTION
## Problem

When the globally activated version of a CLI differs from the version pinned by the local project, cli_launcher relaunches the pinned local installation via `dart run <package>:<executable>`. `dart run` implicitly resolves dependencies before running, and a plain `dart pub get` fails on a Dart pub-workspace that contains Flutter members:

```
Because <pkg> requires the Flutter SDK, version solving failed.
Flutter users should use `flutter pub` instead of `dart pub`.
```

This broke melos consumers such as supabase-flutter, whose Dart-only CI activated a newer global `melos` than the version pinned in the committed `pubspec.lock`, triggering a relaunch of the pinned version (exit 255).

Notably, `_updateDependencies` already picks `flutter pub get` correctly, but the relaunch itself hard-coded `dart run`. Pre-resolving `.dart_tool` with `flutter pub get` is not sufficient either, because a standalone `dart run` re-resolves regardless.

## Fix

Launch the local installation through `flutter pub run` instead of `dart run` when `localInstallation.requiresFlutter`, keeping the launch consistent with how dependencies are resolved in `_updateDependencies`.

## Test

Adds a regression test in `test/e2e_matrix_test.dart` ("relaunch uses the correct SDK tool") asserting the relaunch tool per `PackageStructure`: `flutter pub run` for Flutter workspace members, `dart run` otherwise. Verified it fails without the fix. Full e2e matrix passes.