### PR TITLE
feat: add sdkPath to LocalLaunchConfig to run tools from a specific SDK

### DIFF
--- a/lib/cli_launcher.dart
+++ b/lib/cli_launcher.dart
@@ -594,8 +594,29 @@ class LocalLaunchConfig {
 /// Returns the path to [tool] in the `bin` directory of the SDK at [sdkPath],
 /// or just [tool] if no SDK path is given, so that it is resolved from the
 /// `PATH`.
+///
+/// Throws a [_LaunchError] if the tool does not exist in the SDK, since
+/// starting a non-existent tool fails differently depending on the platform and
+/// without a helpful message.
 String _sdkTool(String? sdkPath, String tool) {
-  return sdkPath == null ? tool : path.join(sdkPath, 'bin', tool);
+  if (sdkPath == null) {
+    return tool;
+  }
+  final toolPath = path.join(sdkPath, 'bin', tool);
+  final candidates = [
+    toolPath,
+    // On Windows the tools are batch files or executables, which the shell
+    // resolves from the extensionless path.
+    if (Platform.isWindows) ...['$toolPath.bat', '$toolPath.exe'],
+  ];
+  if (!candidates.any((candidate) => File(candidate).existsSync())) {
+    throw _LaunchError(
+      1,
+      'Could not find the $tool tool at $toolPath.\n'
+      'Check the sdkPath of the LocalLaunchConfig.',
+    );
+  }
+  return toolPath;
 }
 
 /// Returns the environment for processes that must use the SDK at [sdkPath],

--- a/lib/cli_launcher.dart
+++ b/lib/cli_launcher.dart
@@ -253,14 +253,16 @@ class ExecutableInstallation {
     return upToDate;
   }
 
-  Future<void> _updateDependencies([List<String>? pubGetArgs]) async {
-    final command = requiresFlutter ? 'flutter' : 'dart';
+  Future<void> _updateDependencies(LocalLaunchConfig? config) async {
+    final sdkPath = config?.sdkPath;
+    final command = _sdkTool(sdkPath, requiresFlutter ? 'flutter' : 'dart');
     final result = await _runProcess(
       command,
-      ['pub', 'get', if (pubGetArgs != null) ...pubGetArgs],
+      ['pub', 'get', ...?config?.pubGetArgs],
       // For workspace members, run from the workspace root so that path
       // dependencies are resolved consistently with the existing pubspec.lock.
       workingDirectory: lockFileRoot.path,
+      environment: _sdkEnvironment(sdkPath),
     );
     if (result.exitCode != 0) {
       throw _LaunchError(
@@ -569,7 +571,7 @@ typedef ResolveLocalLaunchConfig =
 /// Configuration options for launching a local installation of an executable.
 class LocalLaunchConfig {
   /// Creates a new local launch configuration.
-  LocalLaunchConfig({this.pubGetArgs, this.dartRunArgs});
+  LocalLaunchConfig({this.pubGetArgs, this.dartRunArgs, this.sdkPath});
 
   /// Additional arguments to pass to `dart pub get` when dependencies are out
   /// of date.
@@ -577,6 +579,48 @@ class LocalLaunchConfig {
 
   /// Additional arguments to pass to `dart run` when launching the executable.
   final List<String>? dartRunArgs;
+
+  /// The path to the Dart or Flutter SDK that is used to resolve dependencies
+  /// and launch the local installation.
+  ///
+  /// The `dart` and `flutter` tools are taken from the `bin` directory of this
+  /// SDK, and that directory is prepended to the `PATH` of the started
+  /// processes, so that the tools and the launched executable use the same SDK.
+  ///
+  /// When `null`, the tools are resolved from the `PATH`.
+  final String? sdkPath;
+}
+
+/// Returns the path to [tool] in the `bin` directory of the SDK at [sdkPath],
+/// or just [tool] if no SDK path is given, so that it is resolved from the
+/// `PATH`.
+String _sdkTool(String? sdkPath, String tool) {
+  return sdkPath == null ? tool : path.join(sdkPath, 'bin', tool);
+}
+
+/// Returns the environment for processes that must use the SDK at [sdkPath],
+/// with the `bin` directory of the SDK prepended to the `PATH`.
+///
+/// Returns `null` if no SDK path is given, so that the environment of the
+/// current process is inherited unchanged.
+Map<String, String>? _sdkEnvironment(String? sdkPath) {
+  if (sdkPath == null) {
+    return null;
+  }
+  // Environment variable names are case-insensitive on Windows, so the
+  // existing key is reused to avoid ending up with two `PATH` entries.
+  final pathKey = Platform.environment.keys.firstWhere(
+    (key) => key.toUpperCase() == 'PATH',
+    orElse: () => 'PATH',
+  );
+  final separator = Platform.isWindows ? ';' : ':';
+  final currentPath = Platform.environment[pathKey];
+  return {
+    pathKey: [
+      path.join(sdkPath, 'bin'),
+      if (currentPath != null && currentPath.isNotEmpty) currentPath,
+    ].join(separator),
+  };
 }
 
 /// An error that indicates the launch process failed with a specific exit code.
@@ -615,11 +659,13 @@ Future<_ProcessOutput> _runProcess(
   String executable,
   List<String> arguments, {
   String? workingDirectory,
+  Map<String, String>? environment,
 }) async {
   final process = await Process.start(
     executable,
     arguments,
     workingDirectory: workingDirectory,
+    environment: environment,
     // Necessary so that `dart.bat`/`flutter.bat` wrapper can be found on
     // Windows.
     runInShell: Platform.isWindows,
@@ -740,7 +786,7 @@ Future<void> _launchFromGlobalInstallation(
     // Ensure that dependencies are up to date so that we can resolve the
     // version of the local installation.
     _debug('Dependencies are out of date. Running pub get.');
-    await localInstallation._updateDependencies(localConfig?.pubGetArgs);
+    await localInstallation._updateDependencies(localConfig);
   }
 
   if (localInstallation != null &&
@@ -758,6 +804,7 @@ Future<void> _launchFromGlobalInstallation(
     // SDK". Using the Flutter tool keeps the launch consistent with how
     // dependencies are resolved in [_updateDependencies].
     final useFlutter = localInstallation.requiresFlutter;
+    final sdkPath = localConfig?.sdkPath;
     _debug(
       'Launching local installation via '
       '"${useFlutter ? 'flutter pub run' : 'dart run'}" '
@@ -766,8 +813,11 @@ Future<void> _launchFromGlobalInstallation(
       'local version: ${localInstallation.version}, '
       'global version: ${globalInstallation.version}).',
     );
+    if (sdkPath != null) {
+      _debug('Using SDK at $sdkPath.');
+    }
     final process = await Process.start(
-      useFlutter ? 'flutter' : 'dart',
+      _sdkTool(sdkPath, useFlutter ? 'flutter' : 'dart'),
       [
         if (useFlutter) 'pub',
         'run',
@@ -779,6 +829,7 @@ Future<void> _launchFromGlobalInstallation(
       ],
       mode: ProcessStartMode.inheritStdio,
       workingDirectory: localInstallation.packageRoot.path,
+      environment: _sdkEnvironment(sdkPath),
       // Necessary so that `dart.bat`/`flutter.bat` wrapper can be found on
       // Windows.
       runInShell: Platform.isWindows,

--- a/test/e2e_matrix_test.dart
+++ b/test/e2e_matrix_test.dart
@@ -309,6 +309,10 @@ void main() {
         // the PATH. An SDK path that does not exist proves that the tools are
         // taken from it, since the launch then fails with the tool path.
 
+        final sdkTool = structure == PackageStructure.flutterWorkspaceMember
+            ? 'flutter'
+            : 'dart';
+
         test('resolveLocalLaunchConfig uses sdkPath to launch', () {
           fixture!.ensureUpToDateTimestamps();
 
@@ -337,7 +341,13 @@ void main() {
               isA<Exception>().having(
                 (e) => e.toString(),
                 'message',
-                contains(p.join(sdkPath, 'bin')),
+                allOf(
+                  contains('Launching local installation'),
+                  contains(
+                    'Could not find the $sdkTool tool at '
+                    '${p.join(sdkPath, 'bin', sdkTool)}.',
+                  ),
+                ),
               ),
             ),
           );
@@ -371,7 +381,10 @@ void main() {
                   'message',
                   allOf(
                     contains('Dependencies are out of date. Running pub get.'),
-                    contains(p.join(sdkPath, 'bin')),
+                    contains(
+                      'Could not find the $sdkTool tool at '
+                      '${p.join(sdkPath, 'bin', sdkTool)}.',
+                    ),
                   ),
                 ),
               ),

--- a/test/e2e_matrix_test.dart
+++ b/test/e2e_matrix_test.dart
@@ -301,6 +301,88 @@ void main() {
           // --enable-asserts is passed via dartRunArgs by resolveLocalLaunchConfig.
           expect(stdout, contains('Assertions are enabled.'));
         });
+
+        // --- resolveLocalLaunchConfig: sdkPath ---
+        //
+        // The SDK path is used for the tools that resolve dependencies and
+        // relaunch the local installation, instead of `dart`/`flutter` from
+        // the PATH. An SDK path that does not exist proves that the tools are
+        // taken from it, since the launch then fails with the tool path.
+
+        test('resolveLocalLaunchConfig uses sdkPath to launch', () {
+          fixture!.ensureUpToDateTimestamps();
+
+          final sdkPath = _findSdkRoot(
+            flutter: structure == PackageStructure.flutterWorkspaceMember,
+          );
+          final (:stdout, :stderr) = fixture!.runCli(
+            workingDirectory: fixture!.consumerDir,
+            arguments: ['--sdk-path=$sdkPath'],
+          );
+          expect(stdout, contains('local=1.0.0'));
+          expect(stderr, contains('Launching local installation'));
+          expect(stderr, contains('Using SDK at $sdkPath.'));
+        });
+
+        test('resolveLocalLaunchConfig launches with tools from sdkPath', () {
+          fixture!.ensureUpToDateTimestamps();
+
+          final sdkPath = p.join(fixture!.tempDir, 'missing_sdk');
+          expect(
+            () => fixture!.runCli(
+              workingDirectory: fixture!.consumerDir,
+              arguments: ['--sdk-path=$sdkPath'],
+            ),
+            throwsA(
+              isA<Exception>().having(
+                (e) => e.toString(),
+                'message',
+                contains(p.join(sdkPath, 'bin')),
+              ),
+            ),
+          );
+        });
+
+        test(
+          'resolveLocalLaunchConfig runs pub get with tools from sdkPath',
+          () {
+            final lockFileDir =
+                fixture!.workspaceRootDir ?? fixture!.consumerDir;
+            final pubspecFile = File(
+              p.join(fixture!.consumerDir, 'pubspec.yaml'),
+            );
+            final lockFile = File(p.join(lockFileDir, 'pubspec.lock'));
+
+            final now = DateTime.now();
+            pubspecFile.setLastModifiedSync(now);
+            lockFile.setLastModifiedSync(
+              now.subtract(const Duration(hours: 1)),
+            );
+
+            final sdkPath = p.join(fixture!.tempDir, 'missing_sdk');
+            expect(
+              () => fixture!.runCli(
+                workingDirectory: fixture!.consumerDir,
+                arguments: ['--sdk-path=$sdkPath'],
+              ),
+              throwsA(
+                isA<Exception>().having(
+                  (e) => e.toString(),
+                  'message',
+                  allOf(
+                    contains('Dependencies are out of date. Running pub get.'),
+                    contains(p.join(sdkPath, 'bin')),
+                  ),
+                ),
+              ),
+            );
+          },
+          skip:
+              installMethod == InstallMethod.pathActivated &&
+                  structure != PackageStructure.standalone
+              ? 'path-activated workspace shares lock file with global CLI'
+              : null,
+        );
       });
     }
   }
@@ -498,6 +580,28 @@ void main(List<String> args) {
     ], runInShell: Platform.isWindows);
     Directory(tempDir).deleteSync(recursive: true);
   }
+}
+
+/// Finds the root directory of the SDK that provides the `dart` tool used to
+/// run the tests, or the `flutter` tool on the PATH when [flutter] is true.
+String _findSdkRoot({required bool flutter}) {
+  if (!flutter) {
+    return p.dirname(p.dirname(Platform.resolvedExecutable));
+  }
+  final result = Process.runSync(
+    Platform.isWindows ? 'where' : 'which',
+    ['flutter'],
+    runInShell: Platform.isWindows,
+    stdoutEncoding: utf8,
+  );
+  if (result.exitCode != 0) {
+    throw Exception('Could not find the flutter tool on the PATH.');
+  }
+  final flutterTool = const LineSplitter()
+      .convert(result.stdout as String)
+      .first
+      .trim();
+  return p.dirname(p.dirname(File(flutterTool).resolveSymbolicLinksSync()));
 }
 
 /// Ensures pubspec.lock and package_config.json are newer than pubspec.yaml so
@@ -850,10 +954,18 @@ void main(List<String> args) {
           return true;
         }());
       },
-      resolveLocalLaunchConfig: args.contains('--local-launch-config')
+      resolveLocalLaunchConfig:
+          args.contains('--local-launch-config') ||
+              args.any((arg) => arg.startsWith('--sdk-path='))
           ? (context) async {
+              final sdkPathArg = args
+                  .where((arg) => arg.startsWith('--sdk-path='))
+                  .firstOrNull;
               return LocalLaunchConfig(
-                dartRunArgs: ['--enable-asserts'],
+                dartRunArgs: args.contains('--local-launch-config')
+                    ? ['--enable-asserts']
+                    : null,
+                sdkPath: sdkPathArg?.substring('--sdk-path='.length),
               );
             }
           : null,


### PR DESCRIPTION
## Description

Adds an `sdkPath` option to `LocalLaunchConfig`, so that an executable can tell `cli_launcher` which Dart or Flutter SDK to use when it resolves dependencies (`pub get`) and relaunches the local installation (`dart run` / `flutter pub run`).

Until now those processes always used `dart`/`flutter` from the `PATH`. Tools such as Melos let users configure the SDK to use for a workspace (for example an SDK managed by FVM), and that configuration could not be applied to the launcher, since it runs before the tool reads its configuration. When no system-wide Flutter SDK is installed the launch fails with a `ProcessException`, and when one is installed it may be the wrong version. See invertase/melos#616 and invertase/melos#1081.

When `sdkPath` is set:

- A relative path is resolved against the current working directory when `LocalLaunchConfig` is created. This keeps tool lookup, `pub get`, relaunch, and the generated environment consistent even though the child processes use different working directories.
- The `dart`/`flutter` tool is taken from the `bin` directory of the SDK.
- The `bin` directory is prepended to the `PATH` of the started processes, so nested tool invocations and the relaunched executable use the same SDK. The existing `PATH` key of the environment is reused, to avoid duplicate keys on Windows.
- If the tool does not exist in the SDK, the launch fails with `Could not find the <tool> tool at <path>.` instead of a platform-dependent process failure. On Windows the `.bat` and `.exe` variants of the tool are accepted.
- A `Using SDK at <path>.` line is logged in verbose mode.

When `sdkPath` is `null`, nothing changes.

The e2e matrix gets five new tests per install method and package structure: launching with the SDK that runs the tests, resolving a relative SDK path for relaunch and `pub get` while verifying the generated `PATH`, and two tests with a non-existent SDK path that verify the tool paths are taken from the SDK for both the relaunch and `pub get`.
