### PR TITLE
feat: add option to launch without running pub get

### DIFF
--- a/lib/cli_launcher.dart
+++ b/lib/cli_launcher.dart
@@ -146,6 +146,11 @@ class ExecutableInstallation {
 
   YamlMap? _loadPubspecLockEntry() {
     final pubspecLockFile = File(path.join(lockFileRoot.path, 'pubspec.lock'));
+    if (!pubspecLockFile.existsSync()) {
+      // Without resolving dependencies there might be no lock file, in which
+      // case the installation is treated like a path dependency.
+      return null;
+    }
     final pubspecLockString = pubspecLockFile.readAsStringSync();
     final pubspecLockYaml = loadYamlDocument(
       pubspecLockString,
@@ -253,11 +258,51 @@ class ExecutableInstallation {
     return upToDate;
   }
 
+  /// The file containing the entry point of the executable, or `null` if the
+  /// package containing it cannot be resolved.
+  ///
+  /// [packageRoot] is the root of the package in which the executable is
+  /// installed, which is not necessarily the package that contains it, so the
+  /// containing package is resolved through the package resolution.
+  File? get _entrypointFile {
+    final packageConfigFile = _packageConfigFile;
+    if (!packageConfigFile.existsSync()) {
+      return null;
+    }
+
+    final packageConfig =
+        jsonDecode(packageConfigFile.readAsStringSync())
+            as Map<String, Object?>;
+    final packages = packageConfig['packages'] as List<Object?>? ?? [];
+    String? rootUri;
+    for (final package in packages.cast<Map<String, Object?>>()) {
+      if (package['name'] == name.package) {
+        rootUri = package['rootUri'] as String?;
+        break;
+      }
+    }
+    if (rootUri == null) {
+      return null;
+    }
+
+    final root = path.normalize(
+      path.join(packageConfigFile.parent.path, Uri.parse(rootUri).toFilePath()),
+    );
+    final pubspec = _parsePubspec(File(path.join(root, 'pubspec.yaml')));
+    final executables = pubspec['executables'] as YamlMap?;
+    final script = executables?[name.executable] as String? ?? name.executable;
+    return File(path.join(root, 'bin', '$script.dart'));
+  }
+
+  /// The file containing the package resolution of the installation.
+  File get _packageConfigFile =>
+      File(path.join(lockFileRoot.path, '.dart_tool', 'package_config.json'));
+
   Future<void> _updateDependencies([List<String>? pubGetArgs]) async {
     final command = requiresFlutter ? 'flutter' : 'dart';
     final result = await _runProcess(
       command,
-      ['pub', 'get', if (pubGetArgs != null) ...pubGetArgs],
+      ['pub', 'get', ...?pubGetArgs],
       // For workspace members, run from the workspace root so that path
       // dependencies are resolved consistently with the existing pubspec.lock.
       workingDirectory: lockFileRoot.path,
@@ -569,10 +614,23 @@ typedef ResolveLocalLaunchConfig =
 /// Configuration options for launching a local installation of an executable.
 class LocalLaunchConfig {
   /// Creates a new local launch configuration.
-  LocalLaunchConfig({this.pubGetArgs, this.dartRunArgs});
+  LocalLaunchConfig({this.pubGetArgs, this.dartRunArgs, this.runPubGet = true});
+
+  /// Whether to resolve dependencies when they are out of date.
+  ///
+  /// When this is `false`, no `pub get` is run, neither by the launcher nor
+  /// implicitly by the Dart SDK: the local installation is launched by running
+  /// its entry point file directly, instead of through `dart run`, which always
+  /// resolves dependencies first.
+  ///
+  /// Launching fails when dependencies have never been resolved, since the
+  /// package resolution of the local installation is required to run it.
+  final bool runPubGet;
 
   /// Additional arguments to pass to `dart pub get` when dependencies are out
   /// of date.
+  ///
+  /// Ignored when [runPubGet] is `false`.
   final List<String>? pubGetArgs;
 
   /// Additional arguments to pass to `dart run` when launching the executable.
@@ -736,11 +794,17 @@ Future<void> _launchFromGlobalInstallation(
     localConfig = await config.resolveLocalLaunchConfig!(launchContext);
   }
 
+  final runPubGet = localConfig?.runPubGet ?? true;
+
   if (localInstallation != null && !localInstallation._pubspecLockIsUpToDate) {
-    // Ensure that dependencies are up to date so that we can resolve the
-    // version of the local installation.
-    _debug('Dependencies are out of date. Running pub get.');
-    await localInstallation._updateDependencies(localConfig?.pubGetArgs);
+    if (runPubGet) {
+      // Ensure that dependencies are up to date so that we can resolve the
+      // version of the local installation.
+      _debug('Dependencies are out of date. Running pub get.');
+      await localInstallation._updateDependencies(localConfig?.pubGetArgs);
+    } else {
+      _debug('Dependencies are out of date, but pub get is disabled.');
+    }
   }
 
   if (localInstallation != null &&
@@ -757,10 +821,30 @@ Future<void> _launchFromGlobalInstallation(
     // `dart pub get` fails on a Flutter workspace with "requires the Flutter
     // SDK". Using the Flutter tool keeps the launch consistent with how
     // dependencies are resolved in [_updateDependencies].
-    final useFlutter = localInstallation.requiresFlutter;
+    //
+    // Both of those implicitly resolve dependencies, so when pub get is
+    // disabled the entry point file is run directly with the Dart VM, which
+    // never invokes pub.
+    final useFlutter = runPubGet && localInstallation.requiresFlutter;
+    final entrypointFile = runPubGet ? null : localInstallation._entrypointFile;
+
+    if (!runPubGet && entrypointFile?.existsSync() != true) {
+      throw _LaunchError(
+        1,
+        'Could not find the entry point of ${config.name} and running pub get '
+        'is disabled.\n'
+        'Run "dart pub get" in ${localInstallation.lockFileRoot.path} and try '
+        'again.',
+      );
+    }
+
+    final launchTool = !runPubGet
+        ? 'dart'
+        : useFlutter
+        ? 'flutter pub run'
+        : 'dart run';
     _debug(
-      'Launching local installation via '
-      '"${useFlutter ? 'flutter pub run' : 'dart run'}" '
+      'Launching local installation via "$launchTool" '
       '(isSelf: ${localInstallation.isSelf}, '
       'isFromPath: ${localInstallation.isFromPath}, '
       'local version: ${localInstallation.version}, '
@@ -770,9 +854,14 @@ Future<void> _launchFromGlobalInstallation(
       useFlutter ? 'flutter' : 'dart',
       [
         if (useFlutter) 'pub',
-        'run',
+        if (runPubGet)
+          'run'
+        else
+          // The entry point is run directly, so the package resolution of the
+          // local installation has to be passed explicitly.
+          '--packages=${localInstallation._packageConfigFile.path}',
         ...?localConfig?.dartRunArgs,
-        config.name.toString(),
+        if (runPubGet) config.name.toString() else entrypointFile!.path,
         _launchContextMarker,
         jsonEncode(launchContext._toJson()),
         ...args,

--- a/test/e2e_matrix_test.dart
+++ b/test/e2e_matrix_test.dart
@@ -301,6 +301,88 @@ void main() {
           // --enable-asserts is passed via dartRunArgs by resolveLocalLaunchConfig.
           expect(stdout, contains('Assertions are enabled.'));
         });
+
+        // --- runPubGet: false ---
+
+        test(
+          'out of date dependencies do not trigger pub get',
+          () {
+            final lockFileDir =
+                fixture!.workspaceRootDir ?? fixture!.consumerDir;
+            final pubspecFile = File(
+              p.join(fixture!.consumerDir, 'pubspec.yaml'),
+            );
+            final lockFile = File(p.join(lockFileDir, 'pubspec.lock'));
+
+            final now = DateTime.now();
+            pubspecFile.setLastModifiedSync(now);
+            lockFile.setLastModifiedSync(
+              now.subtract(const Duration(hours: 1)),
+            );
+
+            final (:stdout, :stderr) = fixture!.runCli(
+              workingDirectory: fixture!.consumerDir,
+              arguments: ['--no-pub'],
+            );
+            expect(stdout, contains('local=1.0.0'));
+            expect(
+              stderr,
+              contains('Dependencies are out of date, but pub get is disabled'),
+            );
+            expect(stderr, isNot(contains('Running pub get')));
+          },
+          skip:
+              installMethod == InstallMethod.pathActivated &&
+                  structure != PackageStructure.standalone
+              ? 'path-activated workspace shares lock file with global CLI'
+              : null,
+        );
+
+        // The local installation is launched without `dart run`, which would
+        // resolve dependencies implicitly, leaving the lock file untouched
+        // even though the pubspec asks for a dependency that is not in it.
+        test(
+          'launching does not resolve dependencies implicitly',
+          () {
+            final lockFileDir =
+                fixture!.workspaceRootDir ?? fixture!.consumerDir;
+            final pubspecFile = File(
+              p.join(fixture!.consumerDir, 'pubspec.yaml'),
+            );
+            final lockFile = File(p.join(lockFileDir, 'pubspec.lock'));
+
+            final pubspecContents = pubspecFile.readAsStringSync();
+            final lockContents = lockFile.readAsStringSync();
+
+            try {
+              pubspecFile.writeAsStringSync(
+                pubspecContents.replaceFirst(
+                  RegExp('^dependencies:', multiLine: true),
+                  'dependencies:\n  collection: ^1.19.0',
+                ),
+              );
+
+              final (:stdout, :stderr) = fixture!.runCli(
+                workingDirectory: fixture!.consumerDir,
+                arguments: ['--no-pub'],
+              );
+              expect(stdout, contains('local=1.0.0'));
+              expect(
+                stderr,
+                contains('Launching local installation via "dart"'),
+              );
+              expect(lockFile.readAsStringSync(), lockContents);
+            } finally {
+              pubspecFile.writeAsStringSync(pubspecContents);
+              lockFile.writeAsStringSync(lockContents);
+            }
+          },
+          skip:
+              installMethod == InstallMethod.pathActivated &&
+                  structure != PackageStructure.standalone
+              ? 'path-activated workspace shares lock file with global CLI'
+              : null,
+        );
       });
     }
   }
@@ -850,10 +932,14 @@ void main(List<String> args) {
           return true;
         }());
       },
-      resolveLocalLaunchConfig: args.contains('--local-launch-config')
+      resolveLocalLaunchConfig:
+          args.contains('--local-launch-config') || args.contains('--no-pub')
           ? (context) async {
               return LocalLaunchConfig(
-                dartRunArgs: ['--enable-asserts'],
+                dartRunArgs: args.contains('--local-launch-config')
+                    ? ['--enable-asserts']
+                    : null,
+                runPubGet: !args.contains('--no-pub'),
               );
             }
           : null,


### PR DESCRIPTION
Closes #13

Adds `LocalLaunchConfig.runPubGet`, defaulting to `true`, so nothing changes unless a CLI opts out. With `runPubGet: false` no dependency resolution happens while launching a local installation, which is what offline and CI environments want when the checked in resolution should be used as is. Melos wants to wire this up to its `--no-pub` flag.

### Why the explicit `pub get` is only half of it

Not running `_updateDependencies` is not enough, because the relaunch itself resolves dependencies: `dart run` runs an implicit `pub get` (silently, when the lock file is genuinely out of date), and `flutter pub run` does the same. So when `runPubGet` is `false` the entry point file is run directly instead:

```
dart --packages=<lock file root>/.dart_tool/package_config.json <entry point> ...
```

The Dart VM does not invoke pub for that, and the explicit `--packages` keeps the package resolution of the local installation, which is needed because the entry point can live outside the directory tree that contains the package config, for example in the pub cache.

The entry point is resolved through that package config, since `packageRoot` is the package the executable is installed in, which is usually the consumer package, not the package that contains the executable. The `executables` section of the resolved package's pubspec is honored, so an executable name that differs from its script name works.

When the entry point cannot be resolved, which is the case when dependencies have never been resolved, launching fails with an error pointing at the directory to run `pub get` in, instead of failing somewhere in the VM.

A missing `pubspec.lock` is no longer a crash when reading the lock entry: the installation is then treated like a path dependency, which is the same fallback already used when the package is not in the lock file.

### Integration with `sdkPath`

This branch includes #26 from `main`. `LocalLaunchConfig` therefore supports both `sdkPath` and `runPubGet`.

When `runPubGet` is `true`, the selected SDK is used for both `pub get` and the normal relaunch. When `runPubGet` is `false`, the entry point is started directly with the Dart binary from `sdkPath`, using the same SDK-prefixed `PATH`. Relative SDK paths are resolved when the configuration is created, including for the direct entry point launch.

### Tests

The e2e matrix covers every install method and package structure, including:

* Out of date dependencies do not trigger `pub get` when the option is set.
* Launching does not resolve dependencies implicitly: a dependency is added to the consumer pubspec that is not in the lock file, and the lock file is unchanged after the run.
* A relative `sdkPath` is honored together with `runPubGet: false`, for both the selected Dart binary and the launched process environment.

`melos format:check`, `melos analyze`, and `melos test` pass locally after merging `main` (108 passing, 14 skipped, macOS, Dart 3.13.0).
